### PR TITLE
Fix build pipeline

### DIFF
--- a/.github/workflows/new_release.yml
+++ b/.github/workflows/new_release.yml
@@ -45,7 +45,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ needs.create_release.outputs.upload_url }}
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./target/pixelj-without-jre-1.0-SNAPSHOT-linux.zip
         asset_name: pixelj-without-jre-1.0-SNAPSHOT-linux.zip
         asset_content_type: application/zip
@@ -79,7 +79,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ needs.create_release.outputs.upload_url }}
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./target/pixelj-without-jre-1.0-SNAPSHOT-windows.zip
         asset_name: pixelj-without-jre-1.0-SNAPSHOT-windows.zip
         asset_content_type: application/zip

--- a/.github/workflows/new_release.yml
+++ b/.github/workflows/new_release.yml
@@ -12,9 +12,11 @@ jobs:
 
   prepare_release:
     runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.prepare_release.outputs.upload_url }}
     steps:
       - name: Create Release
-        id: create_release
+        id: prepare_release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -57,8 +59,6 @@ jobs:
         asset_path: ./target/pixelj-with-jre-1.0-SNAPSHOT-linux.zip
         asset_name: pixelj-with-jre-1.0-SNAPSHOT-linux.zip
         asset_content_type: application/zip
-    - name: Clean after
-      run: mvn -B clean
 
   build_windows:
     runs-on: windows-latest
@@ -93,5 +93,3 @@ jobs:
         asset_path: ./target/pixelj-with-jre-1.0-SNAPSHOT-windows.zip
         asset_name: pixelj-with-jre-1.0-SNAPSHOT-windows.zip
         asset_content_type: application/zip
-    - name: Clean after
-      run: mvn -B clean

--- a/.github/workflows/new_release.yml
+++ b/.github/workflows/new_release.yml
@@ -45,7 +45,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        upload_url: ${{ needs.prepare_release.outputs.upload_url }}
         asset_path: ./target/pixelj-without-jre-1.0-SNAPSHOT-linux.zip
         asset_name: pixelj-without-jre-1.0-SNAPSHOT-linux.zip
         asset_content_type: application/zip
@@ -55,7 +55,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ needs.create_release.outputs.upload_url }}
+        upload_url: ${{ needs.prepare_release.outputs.upload_url }}
         asset_path: ./target/pixelj-with-jre-1.0-SNAPSHOT-linux.zip
         asset_name: pixelj-with-jre-1.0-SNAPSHOT-linux.zip
         asset_content_type: application/zip
@@ -79,7 +79,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        upload_url: ${{ needs.prepare_release.outputs.upload_url }}
         asset_path: ./target/pixelj-without-jre-1.0-SNAPSHOT-windows.zip
         asset_name: pixelj-without-jre-1.0-SNAPSHOT-windows.zip
         asset_content_type: application/zip
@@ -89,7 +89,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ needs.create_release.outputs.upload_url }}
+        upload_url: ${{ needs.prepare_release.outputs.upload_url }}
         asset_path: ./target/pixelj-with-jre-1.0-SNAPSHOT-windows.zip
         asset_name: pixelj-with-jre-1.0-SNAPSHOT-windows.zip
         asset_content_type: application/zip


### PR DESCRIPTION
Hey there!

This should work now, at least does while I tested it in my forked repo.

I've deleted the `nvm clean` thing at the end, you don't really need to clean up the runners as they do that automatically anyway. (=> Less time spent running your action, less minutes used)